### PR TITLE
security hardening

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,7 +9,7 @@ RewriteRule ^apps/([^/\.]+)/?$ etc/apps/$1 [L]
 
 # Deny access to some file types/directories
 RewriteRule ^/?(\.git|\.tx|SQL|config|logs|temp|tests|program\/(include|lib|localization|steps)) - [F]
-RewriteRule ^(etc/tmp|etc/zppy-cache|/etc/lib/pChart2/cache|etc/build) - [F,L,NC]
+RewriteRule ^(etc/tmp|etc/zppy-cache|/etc/lib|etc/cnf|etc/build) - [F,L,NC]
 
 # Disable index listing
 Options -Indexes


### PR DESCRIPTION
/etc/lib and /etc/cnf both contain files that are loaded from within other php scripts so there is no need for them to be publicly available. it would be even better to move them outside web root and allow the path with SP rule si it can be accessed from .php scripts. Until than lets block them here. Furthermore etc/lib contains third party modules that may have vulns.